### PR TITLE
gff2gff / pipeline annotation bugfixes

### DIFF
--- a/CGATPipelines/PipelineUCSC.py
+++ b/CGATPipelines/PipelineUCSC.py
@@ -119,7 +119,7 @@ def getRepeatsFromUCSC(dbhandle, repclasses, outfile):
 
     if PARAMS["ensembl_remove_contigs"]:
         statement.append(
-            ''' --remove-contigs="%(ensembl_remove_contigs)s" ''')
+            ''' --contig-pattern="%(ensembl_remove_contigs)s" ''')
 
     statement.append('''| gzip > %(outfile)s ''')
 

--- a/CGATPipelines/pipeline_annotations.py
+++ b/CGATPipelines/pipeline_annotations.py
@@ -851,7 +851,7 @@ def buildGeneSet(infile, outfile):
         # in quotation marks to avoid confusion with shell special
         # characters such as ( and |
         statement.append(
-            ''' --remove-contigs="%(ensembl_remove_contigs)s" ''')
+            ''' --contig-pattern="%(ensembl_remove_contigs)s" ''')
 
     statement.append(''' | gzip > %(outfile)s ''')
 

--- a/scripts/gff2gff.py
+++ b/scripts/gff2gff.py
@@ -734,7 +734,7 @@ def main(argv=None):
             if options.contig_pattern:
                 to_remove = [re.compile(x)
                              for x in options.contig_pattern.split(",")]
-                if any([x.match(gff.contig) for x in to_remove]):
+                if any([x.search(gff.contig) for x in to_remove]):
                     filtered_contigs[gff.contig] += 1
                     continue
 


### PR DESCRIPTION
Bug fix to gff2gff.py and to enable pipeline_annotations to run when remove_contigs are specified following the change to gff2gff.py parameter names (--contig-pattern replaced --remove-contigs). 