### PR TITLE
Ts fix sra

### DIFF
--- a/CGAT/Sra.py
+++ b/CGAT/Sra.py
@@ -41,6 +41,8 @@ Code
 import CGAT.Pipeline as P
 import os
 import glob
+import CGAT.Fastq as Fastq
+import CGAT.IOTools as IOTools
 
 
 def peek(sra, outdir):
@@ -63,19 +65,24 @@ def peek(sra, outdir):
 
     if len(f) == 1:
         # sra file contains one read: output = prefix.fastq.gz
-        return f
+        pass
+
     elif len(f) == 2:
         # sra file contains read pairs:
         # output = prefix_1.fastq.gz, prefix_2.fastq.gz
         assert ff[0].endswith(
             "_1.fastq.gz") and ff[1].endswith("_2.fastq.gz")
+
     elif len(f) == 3:
         if ff[2].endswith("_3.fastq.gz"):
             f = glob.glob(os.path.join(outdir, "*_[13].fastq.gz"))
         else:
             f = glob.glob(os.path.join(outdir, "*_[13].fastq.gz"))
 
-    return f
+    # check format of fastqs in .sra
+    fastq_format = Fastq.guessFormat(IOTools.openFile(f[0], "r"), raises=False)
+
+    return f, fastq_format
 
 
 def extract(sra, outdir):

--- a/CGAT/Sra.py
+++ b/CGAT/Sra.py
@@ -43,7 +43,7 @@ import os
 import glob
 
 
-def sneak(sra, outdir):
+def peek(sra, outdir):
     ''' returns the full file names for all files which will be extracted'''
     # --split-files creates files called prefix_#.fastq.gz,
     # where # is the read number.
@@ -79,5 +79,8 @@ def sneak(sra, outdir):
 
 
 def extract(sra, outdir):
-    P.execute("""fastq-dump --split-files --gzip --outdir
-                 %(outdir)s %(sra)s""" % locals())
+
+    statement = """fastq-dump --split-files --gzip --outdir
+                 %(outdir)s %(sra)s""" % locals()
+
+    return statement

--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -476,7 +476,7 @@ class Mapper(object):
                 fastqfiles.append(
                     ["%s/%s" % (tmpdir_fastq, os.path.basename(x))
                      for x in sorted(f)])
-                Sra.exract(infile, tmpdir_fastq)
+                Sra.extract(infile, tmpdir_fastq)
 
             elif infile.endswith(".fastq.gz"):
                 format = Fastq.guessFormat(

--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -470,13 +470,13 @@ class Mapper(object):
             elif infile.endswith(".sra"):
                 # sneak preview to determine if paired end or single end
                 outdir = P.getTempDir()
-                f = Sra.sneak(infile, outdir)
+                f = Sra.peek(infile, outdir)
                 E.info("sra file contains the following files: %s" % f)
                 shutil.rmtree(outdir)
                 fastqfiles.append(
                     ["%s/%s" % (tmpdir_fastq, os.path.basename(x))
                      for x in sorted(f)])
-                Sra.extract(infile, tmpdir_fastq)
+                statement.append(Sra.extract(infile, tmpdir_fastq))
 
             elif infile.endswith(".fastq.gz"):
                 format = Fastq.guessFormat(

--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -499,7 +499,7 @@ class Mapper(object):
                         """ % locals())
 
                         fastqfiles.append(
-                            ("%(tmpdir_fastq)s/%(track)s.fastq%(extension)s"
+                            ("%(tmpdir_fastq)s/%(track)s_converted.fastq%(extension)s"
                              % locals(),))
 
                     # paired end fastqs
@@ -523,9 +523,9 @@ class Mapper(object):
                         """ % locals())
 
                         fastqfiles.append(
-                            ("%s/%s.1.fastq%s" %
+                            ("%s/%s_converted.1.fastq%s" %
                              (tmpdir_fastq, track, extension),
-                             "%s/%s.2.fastq%s" %
+                             "%s/%s_converted.2.fastq%s" %
                              (tmpdir_fastq, track, extension)))
                 else:
                     fastqfiles.append(sra_extraction_files)


### PR DESCRIPTION
SRA extraction is now performed as part of the mapping statement rather than locally. 
SRA.sneak() renamed SRA.peek()
SRA.peek() now also returns fastq format and PipelineMapping checks format and adds fastq2fastq.py conversion command to mapping statement if required