### PR TITLE
Pipeline annotations portability

### DIFF
--- a/CGAT/Pipeline.py
+++ b/CGAT/Pipeline.py
@@ -1289,7 +1289,7 @@ def run(**kwargs):
         if 'job_memory' in options:
             spec.append("-l %s=%s" %
                         (PARAMS.get("cluster_memory_resource", "mem_free"),
-                        options["job_memory"]))
+                         options["job_memory"]))
 
         elif "mem_free" in options["cluster_options"] and \
              PARAMS.get("cluster_memory_resource", False):

--- a/CGAT/Pipeline.py
+++ b/CGAT/Pipeline.py
@@ -1285,6 +1285,21 @@ def run(**kwargs):
                                   options.get("outfile", "ruffus")))),
             "%(cluster_options)s"]
 
+        # get memory usage
+        if 'job_memory' in options:
+            spec.append("-l %s=%s" %
+                        PARAMS.get("cluster_memory_resource", "mem_free"),
+                        options["job_memory"])
+
+        elif "mem_free" in options["cluster_options"] and \
+             PARAMS.get("cluster_memory_resource", False):
+
+            options["cluster_options"] = re.sub(
+                "mem_free", PARAMS.get("cluster_memory_resource"),
+                options["cluster_options"])
+            E.warn("use of mem_free in job options is deprecated, please"
+                   "set job_memory local var instead")
+                                                
         # if process has multiple threads, use a parallel environment
         if 'job_threads' in options:
             spec.append(

--- a/CGAT/Pipeline.py
+++ b/CGAT/Pipeline.py
@@ -1288,8 +1288,8 @@ def run(**kwargs):
         # get memory usage
         if 'job_memory' in options:
             spec.append("-l %s=%s" %
-                        PARAMS.get("cluster_memory_resource", "mem_free"),
-                        options["job_memory"])
+                        (PARAMS.get("cluster_memory_resource", "mem_free"),
+                        options["job_memory"]))
 
         elif "mem_free" in options["cluster_options"] and \
              PARAMS.get("cluster_memory_resource", False):

--- a/CGATPipelines/PipelineGO.py
+++ b/CGATPipelines/PipelineGO.py
@@ -244,28 +244,30 @@ def createGOSlimFromENSEMBL(infile, outfile):
 
     dirname = os.path.dirname(outfile)
 
+    goslim_fn = os.path.join(dirname, "goslim.obo")
     statement = '''wget %(go_url_goslim)s
-    --output-document=%(dirname)s/goslim.obo'''
+    --output-document=%(goslim_fn)s'''
     P.run()
 
+    ontology_fn = os.path.join(dirname, "go_onotology.obo")
     statement = '''wget %(go_url_ontology)s
-    --output-document=%(dirname)s/go_ontology.obo'''
+    --output-document=%(ontology_fn)s'''
     P.run()
 
-    job_options = "-l mem_free=5G"
+    job_memory = "5G"
     statement = '''
     map2slim -outmap %(outfile)s.map
-    %(dirname)s/goslim.obo
-    %(dirname)s/go_ontology.obo
+    %(goslim_fn)s
+    %(ontology_fn)s
     '''
     P.run()
 
-    job_options = "-l mem_free=5G"
+    job_memory = "5G"
     statement = '''
     zcat < %(infile)s
     | python %(scriptsdir)s/runGO.py
     --go2goslim
-    --filename-ontology=%(dirname)s/go_ontology.obo
+    --filename-ontology=%(ontology_fn)s
     --slims=%(outfile)s.map
     --log=%(outfile)s.log
     | gzip

--- a/CGATPipelines/pipeline_annotations.py
+++ b/CGATPipelines/pipeline_annotations.py
@@ -1565,7 +1565,7 @@ if PARAMS["genome"].startswith("hg"):
         '''download GWAS catalog.'''
 
         if os.path.exists(outfile):
-            os.path.remove(outfile)
+            os.remove(outfile)
         statement = '''wget http://www.genome.gov/admin/gwascatalog.txt
         -O %(outfile)s'''
         P.run()
@@ -1647,7 +1647,7 @@ if PARAMS["genome"].startswith("hg"):
         track = P.snip(outfile, ".log")
         of = track + "_snps.tsv.gz"
         if os.path.exists(of):
-            os.path.remove(of)
+            os.remove(of)
         statement = \
             '''wget http://distild.jensenlab.org/snps.tsv.gz
             -O %(of)s'''
@@ -1655,7 +1655,7 @@ if PARAMS["genome"].startswith("hg"):
 
         of = track + "_lds.tsv.gz"
         if os.path.exists(of):
-            os.path.remove(of)
+            os.remove(of)
         statement = \
             '''wget http://distild.jensenlab.org/lds.tsv.gz
             -O %(of)s'''


### PR DESCRIPTION
Ahead of the split:
Here is some changes to try an make the pipelines more portable.

*  I have added a `job_memory` option. Similar to `job_options`, if `job_memory `is present in the local name space of `P.run()`, then the memory requirement is added to the cluster submission.
*  The name of the resource to use is now encoded in `cluster_memory_resrouce` of the ini. If someone wants to tell me how to deal with the case of setting a default, other than the hard coded way here, please go ahead.
* If `mem_free` is included in the `job_options` it is parsed out and replaced with a `job_memory` and a warning is issued.

Ian
---
