### PR TITLE
Gtf2gtf methods check

### DIFF
--- a/install-CGAT-tools.sh
+++ b/install-CGAT-tools.sh
@@ -131,17 +131,8 @@ get_cgat_env() {
 
 if [ $TRAVIS_INSTALL ] ; then
 
-   if [ $TEST_PRODUCTION_SCRIPTS ] ; then
-
-      CGAT_HOME=$TRAVIS_BUILD_DIR
-      CONDA_INSTALL_TYPE="cgat-scripts"
-
-   else
-
-      CGAT_HOME=$TRAVIS_BUILD_DIR
-      CONDA_INSTALL_TYPE="cgat-devel"
-
-   fi # if-production scripts
+   CGAT_HOME=$TRAVIS_BUILD_DIR
+   CONDA_INSTALL_TYPE="cgat-devel"
 
 else
 

--- a/scripts/gtf2gtf.py
+++ b/scripts/gtf2gtf.py
@@ -511,7 +511,8 @@ def main(argv=None):
                           "sort",
                           "transcript2genes",
                           "unset-genes"),
-                      help="Method to apply [%default]. Please only select one.")
+                      help="Method to apply [%default]."
+                      "Please only select one.")
 
     parser.set_defaults(
         sort_order="gene",

--- a/scripts/gtf2gtf.py
+++ b/scripts/gtf2gtf.py
@@ -58,7 +58,7 @@ Manipulating gene-models
 ++++++++++++++++++++++++
 
 Options that can be used to alter the features represented in a :term:`gtf`
-file.
+file. Only one method can be specified at once.
 
 Input gtfs need to be sorted so that features for a gene or transcript
 appear consecutively within the file. This can be achevied using
@@ -483,6 +483,7 @@ def main(argv=None):
         "[%default]")
 
     parser.add_option("-m", "--method", dest="method", type="choice",
+                      action="append",
                       choices=(
                           "add-protein-id",
                           "exons2introns",
@@ -510,7 +511,7 @@ def main(argv=None):
                           "sort",
                           "transcript2genes",
                           "unset-genes"),
-                      help="Method to apply [%default].")
+                      help="Method to apply [%default]. Please only select one.")
 
     parser.set_defaults(
         sort_order="gene",
@@ -536,6 +537,11 @@ def main(argv=None):
 
     if options.method is None:
         raise ValueError("please specify a --method")
+
+    if len(options.method) > 1:
+        raise ValueError("multiple --method arguements specified")
+    else:
+        options.method = options.method[0]
 
     if options.method == "set-transcript-to-gene":
 


### PR DESCRIPTION
Fix for issue #93: gtf2gtf will return an error if an attempt is made to specify multiple methods. 