### PR TITLE
add missing "contigs" argument to extendInterval function in bed2bed.py

### DIFF
--- a/scripts/bed2bed.py
+++ b/scripts/bed2bed.py
@@ -420,7 +420,7 @@ def shiftIntervals(iterator, contigs, offset):
 # IMS: new method: extend intervals by set amount
 
 
-def extendInterval(iterator, distance):
+def extendInterval(iterator, contigs, distance):
 
     ninput, noutput, nskipped = 0, 0, 0
     for bed in iterator:


### PR DESCRIPTION
add the missing "contigs" argument to extendInterval function - resolution for issue #222 