### PR TITLE
Account for proper pairs in set-nh of bam2bam.py

### DIFF
--- a/scripts/_bam2bam.pyx
+++ b/scripts/_bam2bam.pyx
@@ -30,6 +30,10 @@ cdef class SetNH:
                 for read in self.stack:
                     if not read.is_unmapped:
                         t = dict(read.tags)
+                        # deal with paired end reads counted
+                        # as multi-mapping
+                        if read.is_proper_pair and nh > 1:
+                            nh -= 1
                         t['NH'] = nh
                         read.tags = list(t.iteritems())
 


### PR DESCRIPTION
Currently bam2bampy --method=set-nh does not account for pair-end reads when counting the number of records for a read in an alignment file.  This can cause filtering issues when selecting uniquely mapped reads.  See issue #241 
Solution: reduce set-nh by 1 if proper paired read and NH:i:n > 1 in _bam2bam.pyx

Requires extension rebuild to implement.

Unit tests run and pass on command-line locally.