### PR TITLE
debug Fastq

### DIFF
--- a/CGAT/Fastq.py
+++ b/CGAT/Fastq.py
@@ -270,6 +270,7 @@ def iterate_convert(infile, format, max_tries=10000, guess=None):
         if len(quals) == 0:
             raise ValueError("could not guess format - ranges incompatible.")
         if len(quals) == 1:
+            cache.append(record)
             break
         cache.append(record)
 


### PR DESCRIPTION
When Fastq.py is trying to guess quality format for the first few records, it occasionally jumps to the next loop before it cache the record, resulting in truncated output.
(Tom corrected it!)