### PR TITLE
Store bed name in readAndIndex iterator

### DIFF
--- a/CGAT/Bed.py
+++ b/CGAT/Bed.py
@@ -414,7 +414,9 @@ def readAndIndex(infile, with_values=False, per_track=False):
             if e.contig not in idx:
                 idx[e.contig] = idx_factory()
             try:
-                if with_values:
+                if with_values == "name":
+                    idx[e.contig].add(e.start, e.end, e.name)
+                elif with_values is True:
                     idx[e.contig].add(e.start, e.end, e)
                 else:
                     idx[e.contig].add(e.start, e.end)


### PR DESCRIPTION
Allow iterating of Bed files saving just name rather than whole bed record by new option to Bed.readAndIndex