### PR TITLE
workaround for bug in biomaRt package using default biomart host

### DIFF
--- a/CGAT/Biomart.py
+++ b/CGAT/Biomart.py
@@ -48,7 +48,18 @@ def importFromBiomart(outfile,
 
     keys = columns.keys()
 
-    mart = R.useMart(biomart=biomart, dataset=dataset, host=host)
+    # The default value for host in the biomaRt package is
+    # www.biomart.org but for some reason R errors if you specify
+    # host manually but then use the default - but it is fine if
+    # host is anything valid apart from www.biomart.org.  So I have
+    # changed this to only specify a value if the value you
+    # are specifying is different to the default KB
+
+    if host == 'www.biomart.org':
+        mart = R.useMart(biomart=biomart, dataset=dataset)
+    else:
+        mart = R.useMart(biomart=biomart, dataset=dataset, host=host)
+
     result = R.getBM(attributes=keys, mart=mart)
 
     outf = IOTools.openFile(outfile, "w")
@@ -102,11 +113,19 @@ def biomart_iterator(columns,
 
     R.library("biomaRt")
 
-    mart = R.useMart(biomart=biomart,
-                     dataset=dataset,
-                     host=host,
-                     path=path,
-                     archive=archive)
+    # The default value for host in the biomaRt package is
+    # www.biomart.org but for some reason R errors if you specify
+    # host manually but then use the default - but it is fine if
+    # host is anything valid apart from www.biomart.org.  So I have
+    # changed this to only specify a value if the value you
+    # are specifying is different to the default KB
+
+    if host == 'www.biomart.org':
+        mart = R.useMart(biomart=biomart, dataset=dataset, path=path,
+                         archive=archive)
+    else:
+        mart = R.useMart(biomart=biomart, dataset=dataset, host=host,
+                         path=path, archive=archive)
 
     if filters is not None:
         filter_names = rpy2.robjects.vectors.StrVector(filters)


### PR DESCRIPTION
When the biomaRt R package calls the useMart function, the default value is 'www.biomart.org'.  If this option is specified when the funciton is called as host='www.biomart.org' there is an error message but if host is not specified it runs on www.biomart.org without the error.  If any other valid path is used, e.g. host='www.ensembl.org' then it also runs fine.  I have changed the code so that if the specified host is 'www.biomart.org' then the function is called without specifying a host.