### PR TITLE
 Remove default values for cluster_* options. 

### DIFF
--- a/CGAT/Experiment.py
+++ b/CGAT/Experiment.py
@@ -783,15 +783,6 @@ def Start(parser=None,
                          help="additional options for cluster jobs, passed "
                          "on to queuing system [%default].")
 
-        parser.set_defaults(without_cluster=False,
-                            cluster_queue_manager="sge",
-                            cluster_queue="all.q",
-                            cluster_memory_resource="mem_free",
-                            cluster_memory_default="2G",
-                            cluster_priority=0,
-                            cluster_num_jobs=None,
-                            cluster_parallel_environment="dedicated",
-                            cluster_options="")
         parser.add_option_group(group)
 
     if add_output_options or add_pipe_options:


### PR DESCRIPTION

Follow discussion in https://github.com/CGATOxford/CGATPipelines/pull/254

Duplicity between:
https://github.com/CGATOxford/CGATPipelines/blob/master/CGATPipelines/Pipeline/Parameters.py#L103
https://github.com/CGATOxford/cgat/blob/master/CGAT/Experiment.py#L786

I think the hard coded defaults should be kept only in Parameters.py
