### PR TITLE
Updates to make code py3.5 compatible

### DIFF
--- a/CGAT/CSV.py
+++ b/CGAT/CSV.py
@@ -44,7 +44,7 @@ def getMapColumn2Type(rows, ignore_empty=False, get_max_values=False):
                 if h not in max_values:
                     max_values[h] = int(row[h])
                 else:
-                    max_values[h] = max(h, int(row[h]))
+                    max_values[h] = max(max_values[h], int(row[h]))
 
             elif isinstance(row[h], float):
                 t = float

--- a/CGAT/CSV2DB.py
+++ b/CGAT/CSV2DB.py
@@ -60,13 +60,12 @@ def executewait(dbhandle, statement, error,
             cc.execute(statement, args)
             return cc
         except sqlite3.OperationalError as e:
-            msg = e.message
             E.warn("import failed: msg=%s, statement=\n  %s" %
-                   (msg, statement))
+                   (str(e), statement))
         # TODO: check for database locked msg
             if not retry:
                 raise e
-            if not re.search("locked", str(msg)):
+            if not re.search("locked", str(e)):
                 raise e
             time.sleep(wait)
             i -= 1

--- a/CGAT/IOTools.py
+++ b/CGAT/IOTools.py
@@ -189,7 +189,7 @@ def touchFile(filename, times=None):
     as empty 'gzip' files, i.e., with a header.
     '''
     existed = os.path.exists(filename)
-    fhandle = file(filename, 'a')
+    fhandle = open(filename, 'a')
 
     if filename.endswith(".gz") and not existed:
         # this will automatically add a gzip header

--- a/CGAT/IndexedFasta.py
+++ b/CGAT/IndexedFasta.py
@@ -1045,9 +1045,15 @@ class PysamIndexedFasta(CGATIndexedFasta):
         sequence = self.mDatabaseFile.fetch(contig, first_pos, last_pos)
 
         if str(strand) in ("-", "0", "-1"):
-            sequence = string.translate(
-                sequence[::-1],
-                string.maketrans("ACGTacgtNn", "TGCAtgcaNn"))
+            try:
+                # works in py2 only
+                sequence = string.translate(
+                    sequence[::-1],
+                    string.maketrans("ACGTacgtNn", "TGCAtgcaNn"))
+            except AttributeError:
+                # works in py3 only
+                sequence = str(sequence[::-1]).translate(
+                    str.maketrans("ACGTacgtNn", "TGCAtgcaNn"))
 
         return sequence
 


### PR DESCRIPTION
I got lots of errors running the cgat code in py3.5. Here are the changes I've required so far:

- CGAT/CSV.py: This seems like a bug in the CSV.py code? I assume the comparison should be between the current max value and the row value? The comparison was previously failing in py3.5 because it was comparing a str to int. 

- CGAT/IndexedFasta.py - The string.translate and string.maketrans functions are now in str.