### PR TITLE
{is} bed merge by name duplicates

### DIFF
--- a/CGAT/scripts/bed2bed.py
+++ b/CGAT/scripts/bed2bed.py
@@ -228,12 +228,12 @@ def merge(iterator,
                     max_end[s] = 0
 
             elif (d > max_distance or
-                  (by_name and last_name[strand] != bed.name)):
+                  (by_name and last_name[strand] and last_name[strand] != bed.name)):
 
                 if to_join[strand]:
-                    yield to_join[strand]
+                  yield to_join[strand]
 
-                to_join[strand] = []
+                to_join[strand] = list()
 
             last = bed
             last_name[strand] = last.name

--- a/CGAT/scripts/bed2bed.py
+++ b/CGAT/scripts/bed2bed.py
@@ -231,7 +231,7 @@ def merge(iterator,
                   (by_name and last_name[strand] and last_name[strand] != bed.name)):
 
                 if to_join[strand]:
-                  yield to_join[strand]
+                    yield to_join[strand]
 
                 to_join[strand] = list()
 


### PR DESCRIPTION
Currently if `--merge-by-name` is set the first time a comparison is done to see if the first and second intervals have the same name, the `last_name[strand]` list will always be empty, thus marking them as having different names, even if the names are the same.

Address half of issue #347 
